### PR TITLE
Minor fixes and addition.

### DIFF
--- a/js/Lib.hx
+++ b/js/Lib.hx
@@ -46,6 +46,10 @@ class Lib {
     js.Node.console.log(js.Boot.__string_rec(v,""));
     #end
   }
+  
+  public static function print( v : Dynamic ) {
+    trace(v);
+  }
 
   public static function eval( code : String ) : Dynamic {
     return untyped __js__("eval")(code);

--- a/js/Node.hx
+++ b/js/Node.hx
@@ -479,7 +479,7 @@ typedef NodeNetSocket = { > NodeEventEmitter,
    Emits:
    data,end,close
  */
-typedef NodeHttpServerReq = {
+typedef NodeHttpServerReq = { >NodeEventEmitter,
   var method:String;
   var url:String;
   var headers:Dynamic;
@@ -493,7 +493,7 @@ typedef NodeHttpServerReq = {
 
 /* 
  */
-typedef NodeHttpServerResp = { > NodeWriteStream,
+typedef NodeHttpServerResp = { > NodeWriteStream, 
   var statusCode:Int;
   function writeContinue():Void;
   function writeHead(statusCode:Int,?reasonPhrase:String,?headers:Dynamic):Void;
@@ -765,6 +765,7 @@ class NodeC {
   public static inline var ASCII = "ascii";
   public static inline var BINARY = "binary";
   public static inline var BASE64 = "base64";
+  public static inline var HEX = "hex";
 
   //events - thanks tmedema
   public static var EVENT_EVENTEMITTER_NEWLISTENER = "newListener";


### PR DESCRIPTION
Hex constant, NodeHttpServerReq typedef extends NodeEventEmitter, and Lib.print (other platforms have it, it's often assumed by third party libraries).
